### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Soul of Waifu is a solo-developer open-source project. All features are 100% fre
 ## 📊 Repository Stats
 
 <div align="center">
-  <img src="https://api.star-history.com/svg?repos=jofizcd/Soul-of-Waifu&type=Date" alt="Star History Chart"/>
+  <img src="https://star-history.dera.page/svg?repos=jofizcd/Soul-of-Waifu&type=Date" alt="Star History Chart"/>
 </div>
 
 <br>

--- a/README_RU.md
+++ b/README_RU.md
@@ -284,7 +284,7 @@ Soul of Waifu — это open-source проект, разрабатываемы�
 ## 📊 Статистика репозитория
 
 <div align="center">
-  <img src="https://api.star-history.com/svg?repos=jofizcd/Soul-of-Waifu&type=Date" alt="Star History Chart"/>
+  <img src="https://star-history.dera.page/svg?repos=jofizcd/Soul-of-Waifu&type=Date" alt="Star History Chart"/>
 </div>
 
 <br>


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer displays properly. This pull request updates the chart link in README.md and README_RU.md to use a working endpoint so the chart is displayed correctly again.